### PR TITLE
Share logo downloaded by worker with webserver

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
             DEBUG: ${DEBUG}
         volumes:
             - "./static:/usr/src/mygpo/staticfiles"
+            - "./media:/usr/src/mygpo/media"
         ports:
             - "8000:8000"
         networks:
@@ -76,6 +77,8 @@ services:
             SECRET_KEY: ${SECRET_KEY}
             DATABASE_URL: postgres://mygpo:mygpo@db/mygpo
             LOGGING_CELERY_LEVEL: INFO
+        volumes:
+            - "./media:/usr/src/mygpo/media"
         entrypoint:
             - celery
             - -A


### PR DESCRIPTION
Hi,

I encountered an issue with podcast's cover logo. They are not display on the website. I can see on the docker-compose log something like "mygpo.web.logo WARNING Cover file cannot be opened: cannot identify image file".

I added a volume so the pictures downloaded by the worker can be seen by the webserver.

Regards,
Pascal Noisette